### PR TITLE
Get playlist by id action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,9 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
+  
   def index
+    #test
   	if(Playlist.find_by(location: "Dublin", genre: "Rock").blank?)
   		generate_playlist
   	else
@@ -17,5 +18,28 @@ class ApplicationController < ActionController::Base
     PlaylistsSong.create(playlist_id: 1, song_id: 1)
 
     render json: Playlist.find_by(location: "Dublin", genre: "Rock").songs
+  end
+
+  def get_playlist_by_id
+    require 'uri'
+    
+    id_value = URI(request.original_url).path.split('/').last
+
+    # Code to check that the last segment of the url passed
+    # is of type int and to handle the case when it is not.
+
+
+
+    if (id_value == "0" || id_value.to_i != 0)
+
+      if (Playlist.find_by(id: id_value).blank?)
+        render json: "Playlist not found, please enter another id."
+      else
+        render json: {:playlist => Playlist.find_by(id: id_value), :songs => Playlist.find_by(id: id_value).songs}
+      end
+
+    else
+      render json: "Invalid request, id must be an Integer. Received " + id_value
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,10 @@ class ApplicationController < ActionController::Base
   end
 
   def generate_playlist
-  	render text: "You have no playlists!"
+    Playlist.create(location: "Dublin", genre: "Rock")
+    Song.create(name: "Luke Agnew's Song", artist_name: "Luke Agnew", url: "google.com", service: "Spotify")
+    PlaylistsSong.create(playlist_id: 1, song_id: 1)
+
+    render json: Playlist.find_by(location: "Dublin", genre: "Rock").songs
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 
+  get '/playlist/:id' => 'application#get_playlist_by_id'
+
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
 


### PR DESCRIPTION
Allows a user to get a playlist by using it's id
e.g. scenefinder.com/playlist/10 will get the playlist of id 10
